### PR TITLE
Make client requests by URI

### DIFF
--- a/lib/apiuri.rb
+++ b/lib/apiuri.rb
@@ -1,0 +1,23 @@
+require 'uri'
+
+class ApiUri
+   VENDOR_HOST = "api.replicated.com"
+   VENDOR_BASE_PATH = "/vendor/v1"
+
+   def self.build_uri(module_name, endpoint = nil, params = nil)
+      uri_base = "https://" << VENDOR_HOST
+      uri = URI(uri_base)
+
+      path = VENDOR_BASE_PATH << "/" << module_name
+      if endpoint
+         path = path << "/" << endpoint
+      end
+      uri.path = path
+
+      if params
+         uri.query = URI.encode_www_form(params)
+      end
+
+      return uri
+   end
+end

--- a/lib/client/client.rb
+++ b/lib/client/client.rb
@@ -4,7 +4,7 @@ require "ostruct"
 require "json"
 
 class ApiClient
-   ENDPOINT = "https://api.replicated.com/vendor/v1"
+   VENDOR_ENDPOINT = "https://api.replicated.com"
    VERB_MAP = {
       :get    => Net::HTTP::Get,
       :post   => Net::HTTP::Post,
@@ -12,9 +12,10 @@ class ApiClient
       :delete => Net::HTTP::Delete
    }
 
-   def initialize(endpoint = ENDPOINT)
-      uri = URI.parse(endpoint)
-      @http = Net::HTTP.new(uri.host, uri.port)
+   def initialize
+      uri = URI.parse(VENDOR_ENDPOINT)
+      @http = Net::HTTP.new(uri.host, uri.port,
+       :use_ssl => uri.scheme == 'https')
    end
 
    def set_token(api_token)

--- a/lib/client/client.rb
+++ b/lib/client/client.rb
@@ -21,8 +21,8 @@ class ApiClient
       @api_token = api_token
    end
 
-   def request_json(method, path, params)
-      response = request(method, path, params)
+   def request_json(method, uri, params = nil)
+      response = request(method, uri, params)
       body = JSON.parse(response.body)
 
       OpenStruct.new(:code => response.code, :body => body)
@@ -30,14 +30,10 @@ class ApiClient
       response
    end
 
-   def request(method, path, params)
+   def request(method, uri, params)
       method_sym = method.downcase.to_sym
-      case method_sym
-      when :get
-         full_path = encode_path_params(path, params)
-         request = VERB_MAP[method_sym].new(full_path)
-      else
-         request = VERB_MAP[method_sym].new(path)
+
+      unless method_sym.is_eql? :get
          request.set_form_data(params)
       end
 
@@ -46,10 +42,5 @@ class ApiClient
       end
 
       @http.request(request)
-   end
-      
-   def encode_path_params(path, params)
-      encoded = URI.encode_www_form(params)
-      [path, encoded].join("?")
    end
 end

--- a/lib/client/client.rb
+++ b/lib/client/client.rb
@@ -4,7 +4,7 @@ require "ostruct"
 require "json"
 
 class ApiClient
-   VENDOR_ENDPOINT = "https://api.replicated.com"
+   VENDOR_HOST = "api.replicated.com"
    VERB_MAP = {
       :get    => Net::HTTP::Get,
       :post   => Net::HTTP::Post,
@@ -13,8 +13,8 @@ class ApiClient
    }
 
    def initialize
-      uri = URI.parse(VENDOR_ENDPOINT)
-      @http = Net::HTTP.new(uri.host, uri.port,
+      # Create persistent HTTP connection
+      @http = Net::HTTP.new(VENDOR_HOST, URI::HTTPS::DEFAULT_PORT,
        :use_ssl => uri.scheme == 'https')
    end
 


### PR DESCRIPTION
Make the uri object for endpoints first class.

Add a class `ApiUri` that handles putting together the full endpoint
urls. This includes GET params.

Modify the client class to accept these full uri objects when making
requests.