### PR TITLE
Fix a bug in the Client

### DIFF
--- a/lib/client/client.rb
+++ b/lib/client/client.rb
@@ -14,8 +14,8 @@ class ApiClient
 
 	def initialize
 		# Create persistent HTTP connection
-		@http = Net::HTTP.new(VENDOR_HOST, URI::HTTPS::DEFAULT_PORT,
-		 :use_ssl => true)
+		@http = Net::HTTP.new(VENDOR_HOST, URI::HTTPS::DEFAULT_PORT)
+		@http.use_ssl = true
 	end
 
 	def set_token(api_token)
@@ -36,7 +36,7 @@ class ApiClient
 
 		request = VERB_MAP[method_sym].new(uri)
 
-		unless method_sym.is_eql? :get
+		unless method_sym == :get
 			request.set_form_data(params)
 		end
 

--- a/lib/client/client.rb
+++ b/lib/client/client.rb
@@ -15,7 +15,7 @@ class ApiClient
 	def initialize
 		# Create persistent HTTP connection
 		@http = Net::HTTP.new(VENDOR_HOST, URI::HTTPS::DEFAULT_PORT,
-		 :use_ssl => uri.scheme == 'https')
+		 :use_ssl => true)
 	end
 
 	def set_token(api_token)


### PR DESCRIPTION
`uri` is not defined here. Let's just default to always connecting on
HTTPS. This is an SSL API afterall.