### PR TITLE
Change API format

### DIFF
--- a/lib/api/app/app.rb
+++ b/lib/api/app/app.rb
@@ -7,48 +7,48 @@ class App < ApiModule
 		method = "GET"
 		endpoint = "app/" + app_id + "/branding"
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri)
+		return @client.request_json(method, uri)
 	end
 
 	def create_branding(app_id:)
 		method = "POST"
 		endpoint = "app/" + app_id + "/branding"
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri)
+		return @client.request_json(method, uri)
 	end
 
 	def list_license_fields(app_id:)
 		method = "GET"
 		endpoint = "app/" + app_id + "/licensefield"
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri)
+		return @client.request_json(method, uri)
 	end
 
 	def create_license_field(app_id:, options:)
 		method = "POST"
 		endpoint = "app/" + app_id + "/licensefield"
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri, options)
+		return @client.request_json(method, uri, options)
 	end
 
 	def edit_license_field(app_id:, license_field_name:, options:)
 		method = "PUT"
 		endpoint = "app/" + app_id + "/licensefield/" + license_field_name
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri, options)
+		return @client.request_json(method, uri, options)
 	end
 
 	def delete_license_field(app_id:, license_field_name:)
 		method = "DELETE"
 		endpoint = "app/" + app_id + "/licensefield/" + license_field_name
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri)
+		return @client.request_json(method, uri)
 	end
 
 	def list_license(app_id:)
 		method = "GET"
 		endpoint = "app/" + app_id + "/licenses"
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri)
+		return @client.request_json(method, uri)
 	end
 end

--- a/lib/api/apps/apps.rb
+++ b/lib/api/apps/apps.rb
@@ -7,27 +7,27 @@ class Apps < ApiModule
 		method = "GET"
 		endpoint = "app"
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri)
+		return @client.request_json(method, uri)
 	end
 
 	def delete(app_id:)
 		method = "DELETE"
 		endpoint = "app/" + app_id
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri)
+		return @client.request_json(method, uri)
 	end
 
 	def delete_branding(app_id:)
 		method = "DELETE"
 		endpoint = "app/" + app_id + "/branding"
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri)
+		return @client.request_json(method, uri)
 	end
 
 	def create(options:)
 		method = "POST"
 		endpoint = "app"
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri, options)
+		return @client.request_json(method, uri, options)
 	end
 end

--- a/lib/api/auditlog/auditlog.rb
+++ b/lib/api/auditlog/auditlog.rb
@@ -8,6 +8,6 @@ class AuditLog < ApiModule
 		method = "GET"
 		endpoint = "auditlogtoken"
 		uri = ApiUri::build_uri(endpoint, options)
-		return self.client.request(method, uri)
+		return @client.request_json(method, uri)
 	end
 end

--- a/lib/api/auth/auth.rb
+++ b/lib/api/auth/auth.rb
@@ -3,27 +3,27 @@ class Auth < ApiModule
 		method = "POST"
 		endpoint = "user/login"
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri, options)
+		return @client.request_json(method, uri, options)
 	end
 
 	def login_otp(options:)
 		method = "POST"
 		endpoint = "user/login/otp"
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri, options)
+		return @client.request_json(method, uri, options)
 	end
 
 	def logout()
 		method = "POST"
 		endpoint = "user/logout"
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri)
+		return @client.request_json(method, uri)
 	end
 
 	def signup(options:)
 		method = "POST"
 		endpoint = "user/signup"
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri, options)
+		return @client.request_json(method, uri, options)
 	end
 end

--- a/lib/api/channel/channel.rb
+++ b/lib/api/channel/channel.rb
@@ -3,34 +3,34 @@ class Channel < ApiModule
 		method = "POST"
 		endpoint = "app/" + app_id + "/channel"
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri, options)
+		return @client.request_json(method, uri, options)
 	end
 
 	def update_channel(app_id:, channel_id:, options:)
 		method = "POST"
 		endpoint = "app/" + app_id + "/channel/" + channel_id
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri, options)
+		return @client.request_json(method, uri, options)
 	end
 
 	def archive_channel(app_id:, channel_id:)
 		method = "POST"
 		endpoint = "app/" + app_id + "/channel/" + channel_id + "/archive"
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri)
+		return @client.request_json(method, uri)
 	end
 
 	def update_release(app_id:, channel_id:, sequence:, options:)
 		method = "POST"
 		endpoint = "app/" + app_id + "/channel/" + channel_id + "/release/" + sequence
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri, options)
+		return @client.request_json(method, uri, options)
 	end
 
 	def list_releases(app_id:, channel_id:)
 		method = "GET"
 		endpoint = "app/" + app_id + "/channel/" + channel_id + "/releases"
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri)
+		return @client.request_json(method, uri)
 	end
 end

--- a/lib/api/license/license.rb
+++ b/lib/api/license/license.rb
@@ -3,49 +3,49 @@ class License < ApiModule
 		method = "POST"
 		endpoint = "license"
 		uri = ApiUri.build_uri(endpoint)
-		return self.client.request(method, uri, options)
+		return @client.request_json(method, uri, options)
 	end
 
 	def get(license_id:)
 		method = "GET"
 		endpoint = "license/" << license_id
 		uri = ApiUri.build_uri(endpoint)
-		return self.client.request(method, uri)
+		return @client.request_json(method, uri)
 	end
 
 	def update(license_id:, options:)
 		method = "PUT"
 		endpoint = "license/" << license_id
 		uri = ApiUri.build_uri(endpoint)
-		return self.client.request(method, uri, options)
+		return @client.request_json(method, uri, options)
 	end
 
 	def archive(license_id:)
 		method = "DELETE"
 		endpoint = "license/" << license_id
 		uri = ApiUri.build_uri(endpoint)
-		return self.client.request(method, uri)
+		return @client.request_json(method, uri)
 	end
 
 	def update_airgap(license_id:)
 		method  = "POST"
 		endpoint = "license/" << license_id << "/airgap/password"
 		uri = ApiUri.build_uri(endpoint)
-		return self.client.request(method, uri)
+		return @client.request_json(method, uri)
 	end
 
 	def update_billing(license_id:, options:)
 		method = "PUT"
 		endpoint = "license/" << license_id << "/billing"	
 		uri = ApiUri.build_uri(endpoint)
-		return self.client.request(method, uri)
+		return @client.request_json(method, uri)
 	end
 
 	def create_billing_event(license_id:, options:)
 		method = "POST"
 		endpoint = "license/" << license_id << "/billling_event"
 		uri = ApiUri.build_uri(endpoint)
-		return self.client.request(method, uri, options)
+		return @client.request_json(method, uri, options)
 	end
 
 	def update_billing_event(license_id:, billing_event_id:, options:)
@@ -53,20 +53,20 @@ class License < ApiModule
 		endpoint = "license/" << license_id << "/billing_event/" <<
 			billing_event_id
 		uri = ApiUri.build_uri(endpoint)
-		return self.client.request(method, uri, options)
+		return @client.request_json(method, uri, options)
 	end
 
 	def update_channel(license_id:, options:)
 		method = "PUT"
 		endpoint = "license/" << license_id << "/channel"
 		uri = ApiUri.build_uri(endpoint)
-		return self.client.request(method, uri, options)
+		return @client.request_json(method, uri, options)
 	end
 
 	def update_expiration(license_id:, options:)
 		method = "PUT"
 		endpoint = "license/" << license_id << "/expire"
 		uri = ApiUri.build_uri(endpoint)
-		return self.client.request(method, uri, options)
+		return @client.request_json(method, uri, options)
 	end
 end

--- a/lib/api/release/release.rb
+++ b/lib/api/release/release.rb
@@ -3,48 +3,48 @@ class Release < ApiModule
 		method = "POST"
 		endpoint = "app/" << appid << "/release"
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri)
+		return @client.request_json(method, uri)
 	end
 
 	def archive(appid:, squence:)
 		method = "POST"
 		endpoint = "app/" << appid << "/" << sequence << "/archive"
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri)
+		return @client.request_json(method, uri)
 	end
 
 	def get_preflight_checks(appid:, sequence:)
 		method = "GET"
 		endpoint = "app/" << appid << "/" << sequence << "/preflightchecks"
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri)
+		return @client.request_json(method, uri)
 	end
 
 	def promote(appid:, sequence:, options:)
 		method = "POST"
 		endpoint = "app/" << appid << "/" << sequence << "/promote"
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri, options)
+		return @client.request_json(method, uri, options)
 	end
 
 	def get_properties(appid:, sequence:)
 		method = "GET"
 		endpoint = "app/" << appid << "/" << sequence << "/properties"
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri)
+		return @client.request_json(method, uri)
 	end
 
 	def get_config(appid:, sequence:)
 		method = "GET"
 		endpoint = "app/" << appid << "/" << sequence << "/raw"
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri)
+		return @client.request_json(method, uri)
 	end
 
 	def update_config(appid:, sequence:)
 		method = "PUT"
 		endpoint = "app/" << appid << "/" << sequence << "/raw"
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri)
+		return @client.request_json(method, uri)
 	end
 end

--- a/lib/api/releases/releases.rb
+++ b/lib/api/releases/releases.rb
@@ -3,13 +3,13 @@ class Releases < ApiModule
 		method = "GET"
 		endpoint = "app/" + app_id + "/releases"
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri)
+		return @client.request_json(method, uri)
 	end
 
 	def get_releases(app_id:, options:)
 		method = "GET"
 		endpoint = "app/" + app_id + "/releases/paged"
 		uri = ApiUri::build_uri(endpoint, options)
-		return self.client.request(method, uri)
+		return @client.request_json(method, uri)
 	end
 end

--- a/lib/api/team/team.rb
+++ b/lib/api/team/team.rb
@@ -7,6 +7,6 @@ class Team < ApiModule
 		method = "POST"
 		endpoint = "team/invite/" << appid << "/signup"
 		uri = ApiUri::build_uri(endpoint)
-		return self.client.request(method, uri, options)
+		return @client.request_json(method, uri, options)
 	end
 end


### PR DESCRIPTION
The `client` variable is a class property, not a static variable, so
change all the use sites for this object to the `@obj` syntax.

Also, all of these calls were directly to `request` which ought to be a
private method. `request_json` is the intended interface.

Performed with a `sed` so please inspect all the of the changes for
errors.