### PR TITLE
Correct the apps endpoint

### DIFF
--- a/lib/api/apps/apps.rb
+++ b/lib/api/apps/apps.rb
@@ -5,7 +5,7 @@ class Apps < ApiModule
 
 	def list()
 		method = "GET"
-		endpoint = "app"
+		endpoint = "apps"
 		uri = ApiUri::build_uri(endpoint)
 		return @client.request_json(method, uri)
 	end


### PR DESCRIPTION
Typo'd the endpoint. This is the only `apps` endpoint.